### PR TITLE
Fix for bug where bookmark search caused errors in FF

### DIFF
--- a/src/suggestion_engine/server/providers/bookmark.js
+++ b/src/suggestion_engine/server/providers/bookmark.js
@@ -1,12 +1,21 @@
+import {isURL} from 'lib/url';
+
 // https://github.com/nwjs/chromium.src/blob/45886148c94c59f45f14a9dc7b9a60624cfa626a/components/omnibox/browser/bookmark_provider.cc
 export default async function bookmarkSuggestions (searchText) {
   const searchCriteria = searchText === '' ? {} : searchText;
-  const results = await browser.bookmarks.search(searchCriteria);
-  return results
-    .map(({ url, title, dateAdded }) => ({
-      type: 'bookmark',
-      score: -1,
-      title,
-      url
-    }));
+  const searchResults = await browser.bookmarks.search(searchCriteria);
+
+  const filteredResults = [];
+  searchResults.forEach(({ url, title, dateAdded }) => {
+    if (isURL(url)) {
+      filteredResults.push({
+        type: 'bookmark',
+        score: -1,
+        title,
+        url
+      });
+    }
+  });
+
+  return filteredResults;
 }


### PR DESCRIPTION
As mentioned in #18 this is a workaround to prevent saka from crashing in FF when it sees invalid URLs in the bookmark search result.