### PR TITLE
Recently Viewed Mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "react/prop-types": "off",
     "react/no-did-mount-set-state": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+    "no-prototype-builtins": "off"
   },
   "env": {
     "webextensions": true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,7 +59,7 @@ module.exports = function karmaConfig(config) {
       maxLogLines: 5, // limit number of lines logged per test
       suppressErrorSummary: true, // do not print error summary
       suppressFailed: false, // print information about failed tests
-      suppressPassed: false, //  print information about passed tests
+      suppressPassed: true, //  do not print information about passed tests
       suppressSkipped: false, // print information about skipped tests
       showSpecTiming: true // print the time elapsed for each spec
     },

--- a/src/background_page/index.js
+++ b/src/background_page/index.js
@@ -1,8 +1,9 @@
 import 'lib/browser_polyfill.js';
 import 'msg/server.js';
-import tabHistory from './tabHistory.js';
+import { tabHistory, recentlyClosed } from './tabHistory.js';
 
 window.tabHistory = tabHistory;
+window.recentlyClosed = recentlyClosed;
 
 let lastTabId;
 

--- a/src/background_page/tabHistory.js
+++ b/src/background_page/tabHistory.js
@@ -8,38 +8,39 @@ const log = listener => (...args) => {
   // if (SAKA_DEBUG) console.log(tabHistory);
 };
 
-function setMostRecentTab(tabId) {
-  const i = tabHistory.indexOf(tabId);
-  if (i !== -1) {
-    tabHistory.splice(i, 1);
+function setMostRecentTab(tabInfo) {
+  const tabIndex = tabHistory.findIndex(tab => tab.tabId === tabInfo.tabId);
+
+  if (tabIndex !== -1) {
+    tabHistory.splice(tabIndex, 1);
   }
-  tabHistory.unshift(tabId);
+  tabHistory.unshift(tabInfo);
 }
 
 browser.tabs.onActivated.addListener(
   log(({ tabId }) => {
-    setMostRecentTab(tabId);
+    setMostRecentTab({ tabId, lastAccessed: Date.now() });
   })
 );
 
 browser.tabs.onRemoved.addListener(
   log(tabId => {
-    const i = tabHistory.indexOf(tabId);
+    const i = tabHistory.findIndex(tab => tab.tabId === tabId);
     tabHistory.splice(i, 1);
   })
 );
 
 browser.tabs.onReplaced.addListener(
   log((addedTabId, removedTabId) => {
-    const i = tabHistory.indexOf(removedTabId);
-    tabHistory[i] = addedTabId;
+    const i = tabHistory.findIndex(tab => tab.tabId === removedTabId);
+    tabHistory[i] = { tabId: addedTabId, lastAccessed: Date.now() };
   })
 );
 
 browser.windows.onFocusChanged.addListener(async windowId => {
   const [tab] = await browser.tabs.query({ currentWindow: true, active: true });
   if (tab && tab.windowId === windowId) {
-    setMostRecentTab(tab.id);
+    setMostRecentTab({ tabId: tab.id, lastAccessed: Date.now() });
   }
 });
 

--- a/src/background_page/tabHistory.js
+++ b/src/background_page/tabHistory.js
@@ -1,7 +1,10 @@
 import 'lib/browser_polyfill.js';
 
 // list of tab ids in order of increasing age since last visit
-const tabHistory = [];
+export const tabHistory = [];
+
+// list of tab ids in order of increasing age since closed
+export const recentlyClosed = [];
 
 const log = listener => (...args) => {
   listener(...args);
@@ -17,6 +20,15 @@ function setMostRecentTab(tabInfo) {
   tabHistory.unshift(tabInfo);
 }
 
+function setMostRecentClosedTab(tabInfo) {
+  const tabIndex = recentlyClosed.findIndex(tab => tab.tabId === tabInfo.tabId);
+
+  if (tabIndex !== -1) {
+    recentlyClosed.splice(tabIndex, 1);
+  }
+  recentlyClosed.unshift(tabInfo);
+}
+
 browser.tabs.onActivated.addListener(
   log(({ tabId }) => {
     setMostRecentTab({ tabId, lastAccessed: Date.now() });
@@ -27,6 +39,7 @@ browser.tabs.onRemoved.addListener(
   log(tabId => {
     const i = tabHistory.findIndex(tab => tab.tabId === tabId);
     tabHistory.splice(i, 1);
+    setMostRecentClosedTab({ tabId, lastAccessed: Date.now() });
   })
 );
 
@@ -43,5 +56,3 @@ browser.windows.onFocusChanged.addListener(async windowId => {
     setMostRecentTab({ tabId: tab.id, lastAccessed: Date.now() });
   }
 });
-
-export default tabHistory;

--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -1,4 +1,3 @@
-
 export const colors = {
   red: 'rgba(228,26,28,1)',
   black: 'rgba(0,0,0,1)',
@@ -9,6 +8,7 @@ export const colors = {
   yellow: 'rgba(255,255,51,1)',
   brown: 'rgba(166,86,40,1)',
   pink: 'rgba(247,129,191,1)',
+  teal: 'rgb(0,77,64,1)',
   gray: 'rgba(153,153,153,1)'
 };
 
@@ -22,6 +22,7 @@ export const fadedColors = {
   yellow: 'rgba(255,255,51,0.44)',
   brown: 'rgba(166,86,40,0.44)',
   pink: 'rgba(247,129,191,0.44)',
+  teal: 'rgb(0,77,64,0.44)',
   gray: 'rgba(153,153,153,0.44)'
 };
 
@@ -30,11 +31,12 @@ export const colorMap = {
   closedTab: colors.black,
   search: colors.green,
   history: colors.red,
+  recentlyViewed: colors.purple,
   bookmark: colors.orange,
   mode: colors.purple,
   // dictionary: colors.purple,
   calculator: colors.brown,
-  command: colors.pink,
+  // command: colors.pink,
   unknown: colors.gray
 };
 
@@ -43,10 +45,11 @@ export const fadedColorMap = {
   closedTab: fadedColors.black,
   search: fadedColors.green,
   history: fadedColors.red,
+  recentlyViewed: fadedColors.purple,
   bookmark: fadedColors.orange,
   mode: fadedColors.purple,
   // dictionary: colors.purple,
   calculator: fadedColors.brown,
-  command: fadedColors.pink,
+  // command: fadedColors.pink,
   unknown: fadedColors.gray
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -30,15 +30,21 @@ export function objectFromArray(array, key) {
   return out;
 }
 
-export async function getFilteredSuggestions(searchString, getSuggestions, threshold) {
+export async function getFilteredSuggestions(
+  searchString,
+  { getSuggestions, threshold, keys }
+) {
   const suggestions = await getSuggestions(searchString);
+  console.error('Fuse Suggestions: ', suggestions);
   const fuse = new Fuse(suggestions, {
     shouldSort: true,
     threshold,
     minMatchCharLength: 1,
     includeMatches: true,
-    keys: ['title', 'url']
+    keys
   });
+
+  console.error('Fuse: ', fuse.search(searchString));
   return fuse.search(searchString).map(({ item, matches, score }) => ({
     ...item,
     score,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -35,7 +35,6 @@ export async function getFilteredSuggestions(
   { getSuggestions, threshold, keys }
 ) {
   const suggestions = await getSuggestions(searchString);
-  console.error('Fuse Suggestions: ', suggestions);
   const fuse = new Fuse(suggestions, {
     shouldSort: true,
     threshold,
@@ -44,7 +43,6 @@ export async function getFilteredSuggestions(
     keys
   });
 
-  console.error('Fuse: ', fuse.search(searchString));
   return fuse.search(searchString).map(({ item, matches, score }) => ({
     ...item,
     score,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -32,8 +32,7 @@ export function objectFromArray(array, key) {
 
 export async function getFilteredSuggestions(
   searchString,
-  getSuggestions,
-  threshold
+  { getSuggestions, threshold, keys }
 ) {
   const suggestions = await getSuggestions(searchString);
   const fuse = new Fuse(suggestions, {

--- a/src/options/Main/OptionsList/DefaultModeSelection.jsx
+++ b/src/options/Main/OptionsList/DefaultModeSelection.jsx
@@ -34,6 +34,9 @@ const DefaultModeSelection = function DefaultModeSelection({
           <option value="history" selected="">
             History
           </option>
+          <option value="recentlyViewed" selected="">
+            Recently Viewed
+          </option>
           <option value="mode" selected="">
             Modes
           </option>

--- a/src/saka/Main/Components/SuggestionList/Components/Suggestion/index.jsx
+++ b/src/saka/Main/Components/SuggestionList/Components/Suggestion/index.jsx
@@ -22,6 +22,8 @@ export default ({
   const incognitoIcon = icons.incognito;
   let suggestionIcon;
 
+  console.log('Platform: ', SAKA_PLATFORM);
+  console.log('Favicon: ', favIconUrl);
   if (incognito) {
     suggestionIcon = (
       <i className="material-icons" aria-hidden="true" style={{ color }}>

--- a/src/saka/Main/Components/SuggestionList/Components/Suggestion/index.jsx
+++ b/src/saka/Main/Components/SuggestionList/Components/Suggestion/index.jsx
@@ -22,8 +22,6 @@ export default ({
   const incognitoIcon = icons.incognito;
   let suggestionIcon;
 
-  console.log('Platform: ', SAKA_PLATFORM);
-  console.log('Favicon: ', favIconUrl);
   if (incognito) {
     suggestionIcon = (
       <i className="material-icons" aria-hidden="true" style={{ color }}>

--- a/src/saka/Main/Components/SuggestionList/Containers/RecentlyViewedSuggestion/index.jsx
+++ b/src/saka/Main/Components/SuggestionList/Containers/RecentlyViewedSuggestion/index.jsx
@@ -1,19 +1,22 @@
 import { h } from 'preact';
+import highlight from 'lib/highlight.jsx';
 import Suggestion from '../../Components/Suggestion/index.jsx';
 
 export default ({
-  suggestion: { title, url, prettyURL },
+  suggestion: { title, url, matches, favIconUrl, incognito },
   selected,
   index,
   onClick
 }) => (
   <Suggestion
     type="recentlyViewed"
-    title={title}
+    title={highlight(title, 'title', matches)}
     titleColor="#000000"
-    secondary={prettyURL}
+    secondary={highlight(url, 'url', matches)} // TODO: highlight matches are for normal URL not pretty URL
     secondaryColor="rgba(63, 81, 245, 1.0)"
     icon="recentlyViewed"
+    favIconUrl={favIconUrl}
+    incognito={incognito}
     url={url}
     selected={selected}
     index={index}

--- a/src/saka/Main/Components/SuggestionList/Containers/RecentlyViewedSuggestion/index.jsx
+++ b/src/saka/Main/Components/SuggestionList/Containers/RecentlyViewedSuggestion/index.jsx
@@ -1,0 +1,22 @@
+import { h } from 'preact';
+import Suggestion from '../../Components/Suggestion/index.jsx';
+
+export default ({
+  suggestion: { title, url, prettyURL },
+  selected,
+  index,
+  onClick
+}) => (
+  <Suggestion
+    type="recentlyViewed"
+    title={title}
+    titleColor="#000000"
+    secondary={prettyURL}
+    secondaryColor="rgba(63, 81, 245, 1.0)"
+    icon="recentlyViewed"
+    url={url}
+    selected={selected}
+    index={index}
+    onClick={onClick}
+  />
+);

--- a/src/saka/Main/Components/SuggestionList/Containers/SuggestionSelector.jsx
+++ b/src/saka/Main/Components/SuggestionList/Containers/SuggestionSelector.jsx
@@ -20,6 +20,8 @@ export default props => {
       return <BookmarkSuggestion {...props} />;
     case 'history':
       return <HistorySuggestion {...props} />;
+    case 'recentlyViewed':
+      return <HistorySuggestion {...props} />;
     case 'command':
       return <CommandSuggestion {...props} />;
     case 'searchEngine':

--- a/src/saka/Main/Components/SuggestionList/Containers/SuggestionSelector.jsx
+++ b/src/saka/Main/Components/SuggestionList/Containers/SuggestionSelector.jsx
@@ -4,6 +4,7 @@ import TabSuggestion from './TabSuggestion/index.jsx';
 import ClosedTabSuggestion from './ClosedTabSuggestion/index.jsx';
 import BookmarkSuggestion from './BookmarkSuggestion/index.jsx';
 import HistorySuggestion from './HistorySuggestion/index.jsx';
+import RecentlyViewedSuggestion from './RecentlyViewedSuggestion/index.jsx';
 import CommandSuggestion from './CommandSuggestion/index.jsx';
 import SearchEngineSuggestion from './SearchEngineSuggestion/index.jsx';
 import UnknownSuggestion from './UnknownSuggestion/index.jsx';
@@ -21,7 +22,7 @@ export default props => {
     case 'history':
       return <HistorySuggestion {...props} />;
     case 'recentlyViewed':
-      return <HistorySuggestion {...props} />;
+      return <RecentlyViewedSuggestion {...props} />;
     case 'command':
       return <CommandSuggestion {...props} />;
     case 'searchEngine':

--- a/src/saka/Main/Containers/StandardSearch/index.jsx
+++ b/src/saka/Main/Containers/StandardSearch/index.jsx
@@ -192,6 +192,12 @@ export default class extends Component {
           this.getNextSearchString();
         }
         break;
+      case 'X':
+        if (ctrlKey(e)) {
+          e.preventDefault();
+          this.props.setMode('recentlyViewed');
+        }
+        break;
       default:
         this.setState({
           undoIndex: this.props.searchHistory.size - 1

--- a/src/saka/Main/Containers/StandardSearch/index.jsx
+++ b/src/saka/Main/Containers/StandardSearch/index.jsx
@@ -243,7 +243,6 @@ export default class extends Component {
       this.props.mode,
       searchStringAtLookup
     );
-    console.log('Suggestions: ', suggestions)
     const { searchString: searchStringNow } = this.state;
     if (searchStringNow === searchStringAtLookup) {
       this.setState({
@@ -278,7 +277,6 @@ export default class extends Component {
       maxSuggestions
     } = this.state;
     const suggestion = suggestions[firstVisibleIndex + selectedIndex];
-    // console.log('render suggestions', suggestions);
 
     if (!showEmptySearchSuggestions && !searchString) {
       return (

--- a/src/saka/Main/Containers/StandardSearch/index.jsx
+++ b/src/saka/Main/Containers/StandardSearch/index.jsx
@@ -243,6 +243,7 @@ export default class extends Component {
       this.props.mode,
       searchStringAtLookup
     );
+    console.log('Suggestions: ', suggestions)
     const { searchString: searchStringNow } = this.state;
     if (searchStringNow === searchStringAtLookup) {
       this.setState({

--- a/src/saka/Main/Containers/StandardSearch/index.jsx
+++ b/src/saka/Main/Containers/StandardSearch/index.jsx
@@ -297,6 +297,8 @@ export default class extends Component {
         </BackgroundImage>
       );
     }
+
+    // TODO: Rename suggestions and suggestion
     return (
       <BackgroundImage suggestion={suggestion}>
         <GUIContainer onWheel={this.handleWheel}>

--- a/src/saka/Main/index.jsx
+++ b/src/saka/Main/index.jsx
@@ -41,7 +41,11 @@ export default class Main extends Component {
 
   fetchSakaSettings = async function fetchSakaSettings() {
     const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
-    const { searchHistory } = await browser.storage.sync.get(['searchHistory']);
+    let { searchHistory } = await browser.storage.sync.get(['searchHistory']);
+    searchHistory =
+      searchHistory !== undefined && searchHistory.length > 0
+        ? new Set(searchHistory)
+        : new Set(['']);
 
     if (sakaSettings !== undefined) {
       const { mode, showEmptySearchSuggestions } = sakaSettings;
@@ -49,19 +53,13 @@ export default class Main extends Component {
         isLoading: false,
         mode,
         showEmptySearchSuggestions,
-        searchHistory:
-          searchHistory !== undefined && searchHistory.length > 0
-            ? new Set(searchHistory)
-            : new Set([''])
+        searchHistory
       };
     }
 
     return {
       isLoading: false,
-      searchHistory:
-        searchHistory !== undefined && searchHistory.length > 0
-          ? new Set(searchHistory)
-          : new Set([''])
+      searchHistory
     };
   };
 
@@ -152,6 +150,8 @@ export default class Main extends Component {
               setMode={setMode}
               shuffleMode={shuffleMode}
               showEmptySearchSuggestions={showEmptySearchSuggestions}
+              searchHistory={searchHistory}
+              updateSearchHistory={this.updateSearchHistory}
             />
           );
         default:

--- a/src/saka/Main/index.jsx
+++ b/src/saka/Main/index.jsx
@@ -9,7 +9,14 @@ export default class Main extends Component {
 
     this.state = {
       mode: 'tab',
-      modes: ['mode', 'tab', 'closedTab', 'bookmark', 'history'],
+      modes: [
+        'mode',
+        'tab',
+        'closedTab',
+        'bookmark',
+        'history',
+        'recentlyViewed'
+      ],
       isLoading: true,
       showEmptySearchSuggestions: true
     };
@@ -99,6 +106,16 @@ export default class Main extends Component {
             <StandardSearch
               mode={mode}
               placeholder="History"
+              setMode={setMode}
+              shuffleMode={shuffleMode}
+              showEmptySearchSuggestions={showEmptySearchSuggestions}
+            />
+          );
+        case 'recentlyViewed':
+          return (
+            <StandardSearch
+              mode={mode}
+              placeholder="Recently Viewed"
               setMode={setMode}
               shuffleMode={shuffleMode}
               showEmptySearchSuggestions={showEmptySearchSuggestions}

--- a/src/suggestion_engine/server/index.js
+++ b/src/suggestion_engine/server/index.js
@@ -19,6 +19,12 @@ export async function activateSuggestion(suggestion) {
     case 'history':
       await browser.tabs.create({ url: suggestion.url });
       break;
+    case 'recentlyViewed':
+      await activateSuggestion({
+        ...suggestion,
+        type: suggestion.originalType
+      });
+      break;
     default:
       console.error(
         `activation not yet implemented for suggestions of type ${

--- a/src/suggestion_engine/server/providers/bookmark.js
+++ b/src/suggestion_engine/server/providers/bookmark.js
@@ -26,7 +26,11 @@ export default async function bookmarkSuggestions(searchString) {
   const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
 
   if (searchString && sakaSettings.enableFuzzySearch) {
-    return getFilteredSuggestions(searchString, allBookmarkSuggestions, 1);
+    return getFilteredSuggestions(searchString, {
+      getSuggestions: allBookmarkSuggestions,
+      threshold: 1,
+      keys: ['title', 'url']
+    });
   }
 
   return allBookmarkSuggestions(searchString);

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -2,7 +2,7 @@ import { isSakaUrl } from 'lib/url.js';
 import { filter } from 'rxjs/operator/filter';
 import { getFilteredSuggestions } from 'lib/utils.js';
 
-async function getAllSuggestions() {
+export async function getAllSuggestions() {
   const sessions = await browser.sessions.getRecentlyClosed();
   const filteredSessions = [];
 
@@ -16,7 +16,10 @@ async function getAllSuggestions() {
     }
   }
 
+  console.log('Session: ', filteredSessions);
+
   return filteredSessions.map(session => {
+    const lastModified = session.lastAccessed;
     const { id, sessionId, title, url, favIconUrl, incognito } = session.tab;
     return {
       type: 'closedTab',
@@ -26,7 +29,8 @@ async function getAllSuggestions() {
       title,
       url,
       favIconUrl: incognito ? null : favIconUrl,
-      incognito
+      incognito,
+      lastAccessed: lastModified
     };
   });
 }
@@ -34,5 +38,9 @@ async function getAllSuggestions() {
 export default async function closedTabSuggestions(searchString) {
   return searchString === ''
     ? getAllSuggestions()
-    : getFilteredSuggestions(searchString, getAllSuggestions, 0.5);
+    : getFilteredSuggestions(searchString, {
+        getSuggestions: getAllSuggestions,
+        threshold: 0.5,
+        keys: ['title', 'url']
+      });
 }

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -19,7 +19,7 @@ export async function getAllSuggestions() {
   console.log('Session: ', filteredSessions);
 
   return filteredSessions.map(session => {
-    const lastModified = session.lastAccessed;
+    const { lastModified } = session;
     const { id, sessionId, title, url, favIconUrl, incognito } = session.tab;
     return {
       type: 'closedTab',

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -16,8 +16,6 @@ export async function getAllSuggestions() {
     }
   }
 
-  console.log('Session: ', filteredSessions);
-
   return filteredSessions.map(session => {
     const { lastModified } = session;
     const { id, sessionId, title, url, favIconUrl, incognito } = session.tab;

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -1,5 +1,6 @@
 import { isSakaUrl } from 'lib/url.js';
 import { filter } from 'rxjs/operator/filter';
+import { allTabSuggestions } from './tab.js';
 import { getFilteredSuggestions } from 'lib/utils.js';
 
 export async function getAllSuggestions() {

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -37,11 +37,8 @@ export async function getAllSuggestions() {
 // TODO: Remove when Chrome gets proper timestamp
 export async function recentlyClosedTabSuggestions() {
   const { recentlyClosed } = await browser.runtime.getBackgroundPage();
-  const tabs = await allTabSuggestions();
   const sessions = await browser.sessions.getRecentlyClosed();
   const filteredSessions = [];
-
-  console.log('RECENT: ', recentlyClosed);
 
   // TODO: This for loop is currently flagged by the airbnb eslint rules.
   // See: https://github.com/airbnb/javascript/issues/1271
@@ -55,9 +52,7 @@ export async function recentlyClosedTabSuggestions() {
 
   return filteredSessions
     .map(session => {
-      console.log('Session: ', session);
       const foundTab = recentlyClosed.findIndex(tab => {
-        console.log('Tab: ', tab);
         return tab.tabId === session.tab.id;
       });
 

--- a/src/suggestion_engine/server/providers/closedTab.js
+++ b/src/suggestion_engine/server/providers/closedTab.js
@@ -33,6 +33,56 @@ export async function getAllSuggestions() {
   });
 }
 
+// TODO: Remove when Chrome gets proper timestamp
+export async function recentlyClosedTabSuggestions() {
+  const { recentlyClosed } = await browser.runtime.getBackgroundPage();
+  const tabs = await allTabSuggestions();
+  const sessions = await browser.sessions.getRecentlyClosed();
+  const filteredSessions = [];
+
+  console.log('RECENT: ', recentlyClosed);
+
+  // TODO: This for loop is currently flagged by the airbnb eslint rules.
+  // See: https://github.com/airbnb/javascript/issues/1271
+  // Not disabling the rule as this might be fixable in the future using filter.
+  // This for loop is needed at the moment as a workaround since filter does not support async.
+  for (const session of sessions) {
+    if (session.tab && !await isSakaUrl(session.tab.url)) {
+      filteredSessions.push(session);
+    }
+  }
+
+  return filteredSessions
+    .map(session => {
+      console.log('Session: ', session);
+      const foundTab = recentlyClosed.findIndex(tab => {
+        console.log('Tab: ', tab);
+        return tab.tabId === session.tab.id;
+      });
+
+      if (foundTab !== -1) {
+        return { ...session, lastModified: recentlyClosed.tab.lastAccessed };
+      }
+
+      return session;
+    })
+    .map(session => {
+      const { lastModified } = session;
+      const { id, sessionId, title, url, favIconUrl, incognito } = session.tab;
+      return {
+        type: 'closedTab',
+        tabId: id,
+        sessionId,
+        score: undefined,
+        title,
+        url,
+        favIconUrl: incognito ? null : favIconUrl,
+        incognito,
+        lastAccessed: lastModified
+      };
+    });
+}
+
 export default async function closedTabSuggestions(searchString) {
   return searchString === ''
     ? getAllSuggestions()

--- a/src/suggestion_engine/server/providers/history.js
+++ b/src/suggestion_engine/server/providers/history.js
@@ -17,7 +17,7 @@ async function allHistorySuggestions(searchText) {
     ({ url, title, lastVisitTime, visitCount, typedCount }) => ({
       type: 'history',
       score: visitCount + typedCount,
-      lastVisitTime,
+      lastAccessed: lastVisitTime,
       title,
       url
     })
@@ -28,7 +28,11 @@ export default async function historySuggestions(searchString) {
   const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
 
   if (searchString && sakaSettings.enableFuzzySearch) {
-    return getFilteredSuggestions(searchString, allHistorySuggestions, 1);
+    return getFilteredSuggestions(searchString, {
+      getSuggestions: allHistorySuggestions,
+      threshold: 1,
+      keys: ['title', 'url']
+    });
   }
 
   return allHistorySuggestions(searchString);

--- a/src/suggestion_engine/server/providers/history.js
+++ b/src/suggestion_engine/server/providers/history.js
@@ -17,7 +17,7 @@ export async function allHistorySuggestions(searchText) {
     ({ url, title, lastVisitTime, visitCount, typedCount }) => ({
       type: 'history',
       score: visitCount + typedCount,
-      lastAccessed: lastVisitTime,
+      lastAccessed: lastVisitTime * 0.001,
       title,
       url
     })

--- a/src/suggestion_engine/server/providers/history.js
+++ b/src/suggestion_engine/server/providers/history.js
@@ -2,7 +2,6 @@ import { isSakaUrl } from 'lib/url.js';
 import { getFilteredSuggestions } from 'lib/utils.js';
 
 export async function allHistorySuggestions(searchText) {
-  console.log('Starting History....');
   const results = await browser.history.search({
     text: searchText
   });

--- a/src/suggestion_engine/server/providers/history.js
+++ b/src/suggestion_engine/server/providers/history.js
@@ -1,7 +1,8 @@
 import { isSakaUrl } from 'lib/url.js';
 import { getFilteredSuggestions } from 'lib/utils.js';
 
-async function allHistorySuggestions(searchText) {
+export async function allHistorySuggestions(searchText) {
+  console.log('Starting History....');
   const results = await browser.history.search({
     text: searchText
   });

--- a/src/suggestion_engine/server/providers/index.js
+++ b/src/suggestion_engine/server/providers/index.js
@@ -4,4 +4,5 @@ export { default as mode } from './mode.js';
 // export { default as commands } from './commands';
 export { default as history } from './history.js';
 export { default as bookmark } from './bookmark.js';
+export { default as recentlyViewed } from './recentlyViewed.js';
 // export { default as searchEngine } from './searchEngine';

--- a/src/suggestion_engine/server/providers/mode.js
+++ b/src/suggestion_engine/server/providers/mode.js
@@ -38,6 +38,15 @@ const suggestions = [
     color: colorMap.history,
     fadedColor: fadedColorMap.history,
     icon: 'history'
+  },
+  {
+    type: 'mode',
+    label: 'Recently Viewed',
+    mode: 'recentlyViewed',
+    shortcut: `${ctrlChar}-shift-x`,
+    color: colorMap.recentlyViewed,
+    fadedColor: fadedColorMap.recentlyViewed,
+    icon: 'timelapse'
   }
 
   // {

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -21,7 +21,9 @@ async function allRecentlyViewedSuggestions(searchString) {
     tab => !openAndClosedTabsMap.hasOwnProperty(tab.url)
   );
 
-  return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs];
+  return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs].map(
+    tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' })
+  );
 }
 
 function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -1,4 +1,4 @@
-import { getFilteredSuggestions, objectFromArray } from 'lib/utils.js';
+import { getFilteredSuggestions } from 'lib/utils.js';
 import tabSuggestions, { allTabSuggestions } from './tab.js';
 import { getAllSuggestions as getAllClosedTabs } from './closedTab.js';
 import { allHistorySuggestions as getAllHistoryTabs } from './history.js';

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -25,8 +25,6 @@ async function allRecentlyViewedSuggestions(searchString) {
     openTabs = await tabSuggestions(searchString);
     closedTabs = await getAllClosedTabs(searchString);
   }
-  console.warn('Open: ', openTabs);
-  console.warn('Closed: ', closedTabs);
 
   const filteredClosedTabs = closedTabs.filter(tab =>
     openTabs.every(openTab => openTab.url !== tab.url)
@@ -38,12 +36,6 @@ async function allRecentlyViewedSuggestions(searchString) {
     )
   );
 
-  console.warn(
-    'Result: ',
-    [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs]
-      .map(tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' }))
-      .sort(compareRecentlyViewedSuggestions)
-  );
   return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs]
     .map(tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' }))
     .sort(compareRecentlyViewedSuggestions);

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -1,9 +1,10 @@
 import { getFilteredSuggestions, objectFromArray } from 'lib/utils.js';
-import { allTabSuggestions as getAllOpenTabs } from './tab.js';
+import tabSuggestions, { allTabSuggestions } from './tab.js';
 import { getAllSuggestions as getAllClosedTabs } from './closedTab.js';
 
 async function allRecentlyViewedSuggestions(searchString) {
-  const openTabs = await getAllOpenTabs(searchString);
+  console.warn('allRecentlyViewedSuggestions starting...');
+  const openTabs = await tabSuggestions(searchString);
   const closedTabs = await getAllClosedTabs(searchString);
 
   const closedTabsMap = objectFromArray(closedTabs, 'url');
@@ -22,20 +23,23 @@ function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
   return suggestion2.lastAccessed - suggestion1.lastAccessed;
 }
 
+async function filteredRecentlyViewedSuggestions(searchString) {
+  const tabs = await allTabSuggestions();
+  const closedTabs = await getAllClosedTabs(searchString);
+
+  return [...tabs, ...Object.values(closedTabs)];
+}
+
 export default async function recentlyViewedSuggestions(searchString) {
-  const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
-
-  // if (sakaSettings.enableFuzzySearch) {
-  //   return getFilteredSuggestions(searchString, {
-  //     getSuggestions: allRecentlyViewedSuggestions,
-  //     threshold: 1,
-  //     keys: ['lastAccessed']
-  //   });
-  // }
-
   const suggestions = await allRecentlyViewedSuggestions(searchString);
-  const sorted = suggestions.sort(compareRecentlyViewedSuggestions);
-  console.error('Sorted: ', sorted);
 
-  return sorted;
+  if (searchString !== undefined) {
+    return suggestions.sort(compareRecentlyViewedSuggestions);
+  }
+
+  return getFilteredSuggestions(searchString, {
+    getSuggestions: filteredRecentlyViewedSuggestions,
+    threshold: 0.5,
+    keys: ['title', 'url']
+  });
 }

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -3,7 +3,38 @@ import tabSuggestions, { allTabSuggestions } from './tab.js';
 import { getAllSuggestions as getAllClosedTabs } from './closedTab.js';
 import { allHistorySuggestions as getAllHistoryTabs } from './history.js';
 
-async function allRecentlyViewedSuggestions(searchString) {
+function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
+  return suggestion2.lastAccessed - suggestion1.lastAccessed;
+}
+
+async function getChromeRecentlyViewed(searchString) {
+  const openTabs = await tabSuggestions(searchString);
+  const closedTabs = await getAllClosedTabs(searchString);
+  const historyTabs = await getAllHistoryTabs(searchString);
+
+  const filteredClosedTabs = closedTabs.filter(tab =>
+    openTabs.every(openTab => openTab.url !== tab.url)
+  );
+
+  const filteredHistoryTabs = historyTabs.filter(tab =>
+    [...openTabs, ...filteredClosedTabs].every(
+      openOrClosedTab => openOrClosedTab.url !== tab.url
+    )
+  );
+
+  const sortedClosedAndHistoryTabs = [
+    ...filteredClosedTabs,
+    ...filteredHistoryTabs
+  ].sort(compareRecentlyViewedSuggestions);
+
+  return [...openTabs, ...sortedClosedAndHistoryTabs].map(tab => ({
+    ...tab,
+    originalType: tab.type,
+    type: 'recentlyViewed'
+  }));
+}
+
+async function getFirefoxRecentlyViewed(searchString) {
   const openTabs = await tabSuggestions(searchString);
   const closedTabs = await getAllClosedTabs(searchString);
   const historyTabs = await getAllHistoryTabs(searchString);
@@ -23,8 +54,12 @@ async function allRecentlyViewedSuggestions(searchString) {
   );
 }
 
-function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
-  return suggestion2.lastAccessed - suggestion1.lastAccessed;
+async function allRecentlyViewedSuggestions(searchString) {
+  if (SAKA_PLATFORM === 'chrome') {
+    return getChromeRecentlyViewed(searchString);
+  }
+
+  return getFirefoxRecentlyViewed(searchString);
 }
 
 async function filteredRecentlyViewedSuggestions(searchString) {
@@ -39,15 +74,27 @@ async function filteredRecentlyViewedSuggestions(searchString) {
   ].map(tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' }));
 }
 
-export default async function recentlyViewedSuggestions(searchString) {
-  if (searchString === '') {
-    const suggestions = await allRecentlyViewedSuggestions(searchString);
-    return suggestions.sort(compareRecentlyViewedSuggestions);
-  }
-
-  return getFilteredSuggestions(searchString, {
+async function getFilteredRecentlyViewedSuggestions(searchString) {
+  const filteredSuggestions = await getFilteredSuggestions(searchString, {
     getSuggestions: filteredRecentlyViewedSuggestions,
     threshold: 0.5,
     keys: ['title', 'url']
   });
+
+  return filteredSuggestions.filter(
+    (suggestion, index) =>
+      filteredSuggestions.findIndex(
+        filteredSuggestion =>
+          filteredSuggestion.url === suggestion.url &&
+          filteredSuggestion.title === suggestion.title
+      ) === index
+  );
+}
+
+export default async function recentlyViewedSuggestions(searchString) {
+  if (searchString === '') {
+    return allRecentlyViewedSuggestions(searchString);
+  }
+
+  return getFilteredRecentlyViewedSuggestions(searchString);
 }

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -35,11 +35,6 @@ async function filteredRecentlyViewedSuggestions(searchString) {
   const closedTabs = await getAllClosedTabs(searchString);
   const historyTabs = await getAllHistoryTabs(searchString);
 
-  console.warn('Filtered: ', [
-    ...tabs,
-    ...Object.values(closedTabs),
-    ...Object.values(historyTabs)
-  ]);
   return [
     ...tabs,
     ...Object.values(closedTabs),
@@ -50,7 +45,6 @@ async function filteredRecentlyViewedSuggestions(searchString) {
 export default async function recentlyViewedSuggestions(searchString) {
   if (searchString === '') {
     const suggestions = await allRecentlyViewedSuggestions(searchString);
-    console.warn('Suggestions: ', suggestions);
     return suggestions.sort(compareRecentlyViewedSuggestions);
   }
 

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -24,17 +24,25 @@ async function allRecentlyViewedSuggestions(searchString) {
   console.error('Closed: ', closedTabs);
   console.error('History: ', historyTabs);
 
+  const openTabsMap = objectFromArray(openTabs, 'url');
   const filteredClosedTabs = closedTabs.filter(
-    tab => openTabs.indexOf(tab.url) === -1
+    tab => !openTabsMap.hasOwnProperty(tab.url)
   );
 
-  const openAndClosedTabs = [...openTabs, ...filteredClosedTabs];
+  const openAndClosedTabsMap = objectFromArray(
+    [...openTabs, ...filteredClosedTabs],
+    'url'
+  );
   const filteredHistoryTabs = historyTabs.filter(
-    tab => openAndClosedTabs.indexOf(tab.url) === -1
+    tab => !openAndClosedTabsMap.hasOwnProperty(tab.url)
   );
 
-  console.warn('Recent: ', [...openAndClosedTabs, ...filteredHistoryTabs]);
-  return [...openAndClosedTabs, ...filteredHistoryTabs];
+  console.warn('Recent: ', [
+    ...openTabs,
+    ...filteredClosedTabs,
+    ...filteredHistoryTabs
+  ]);
+  return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs];
 }
 
 function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
@@ -52,6 +60,10 @@ export default async function recentlyViewedSuggestions(searchString) {
   const suggestions = await allRecentlyViewedSuggestions(searchString);
 
   if (searchString !== undefined) {
+    console.warn(
+      'Sorted: ',
+      suggestions.sort(compareRecentlyViewedSuggestions)
+    );
     return suggestions.sort(compareRecentlyViewedSuggestions);
   }
 

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -49,9 +49,9 @@ async function getFirefoxRecentlyViewed(searchString) {
     )
   );
 
-  return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs].map(
-    tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' })
-  );
+  return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs]
+    .map(tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' }))
+    .sort(compareRecentlyViewedSuggestions);
 }
 
 async function allRecentlyViewedSuggestions(searchString) {
@@ -93,7 +93,7 @@ async function getFilteredRecentlyViewedSuggestions(searchString) {
 
 export default async function recentlyViewedSuggestions(searchString) {
   if (searchString === '') {
-    return allRecentlyViewedSuggestions(searchString);
+    return allRecentlyViewedSuggestions(searchString, SAKA_PLATFORM);
   }
 
   return getFilteredRecentlyViewedSuggestions(searchString);

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -62,11 +62,6 @@ async function filteredRecentlyViewedSuggestions(searchString) {
 }
 
 async function getFilteredRecentlyViewedSuggestions(searchString) {
-  console.warn(
-    'filteredRecentlyViewedSuggestions: ',
-    await filteredRecentlyViewedSuggestions(searchString)
-  );
-
   const filteredSuggestions = await getFilteredSuggestions(searchString, {
     getSuggestions: filteredRecentlyViewedSuggestions,
     threshold: 0.5,

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -62,6 +62,11 @@ async function filteredRecentlyViewedSuggestions(searchString) {
 }
 
 async function getFilteredRecentlyViewedSuggestions(searchString) {
+  console.warn(
+    'filteredRecentlyViewedSuggestions: ',
+    await filteredRecentlyViewedSuggestions(searchString)
+  );
+
   const filteredSuggestions = await getFilteredSuggestions(searchString, {
     getSuggestions: filteredRecentlyViewedSuggestions,
     threshold: 0.5,

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -1,22 +1,40 @@
 import { getFilteredSuggestions, objectFromArray } from 'lib/utils.js';
 import tabSuggestions, { allTabSuggestions } from './tab.js';
 import { getAllSuggestions as getAllClosedTabs } from './closedTab.js';
+import { allHistorySuggestions as getAllHistoryTabs } from './history.js';
 
 async function allRecentlyViewedSuggestions(searchString) {
-  console.warn('allRecentlyViewedSuggestions starting...');
   const openTabs = await tabSuggestions(searchString);
   const closedTabs = await getAllClosedTabs(searchString);
+  const historyTabs = await getAllHistoryTabs(searchString);
 
-  const closedTabsMap = objectFromArray(closedTabs, 'url');
-  const recentOpenTabs = openTabs.map(openTab => {
-    if (closedTabsMap[openTab.url]) {
-      delete closedTabsMap[openTab.url];
-    }
-    return openTab;
-  });
+  // const closedTabsMap = objectFromArray(closedTabs, 'url');
+  // const historyTabsMap = objectFromArray(historyTabs, 'url');
 
-  console.warn('ASD: ', [...recentOpenTabs, ...Object.values(closedTabsMap)]);
-  return [...recentOpenTabs, ...Object.values(closedTabsMap)];
+  // const recentOpenTabs = openTabs.map(openTab => {
+  //   if (closedTabsMap[openTab.url]) {
+  //     delete closedTabsMap[openTab.url];
+  //   }
+  //   return openTab;
+  // });
+
+  // return [...recentOpenTabs, ...Object.values(closedTabsMap)];
+
+  console.error('Tabs: ', openTabs);
+  console.error('Closed: ', closedTabs);
+  console.error('History: ', historyTabs);
+
+  const filteredClosedTabs = closedTabs.filter(
+    tab => openTabs.indexOf(tab.url) === -1
+  );
+
+  const openAndClosedTabs = [...openTabs, ...filteredClosedTabs];
+  const filteredHistoryTabs = historyTabs.filter(
+    tab => openAndClosedTabs.indexOf(tab.url) === -1
+  );
+
+  console.warn('Recent: ', [...openAndClosedTabs, ...filteredHistoryTabs]);
+  return [...openAndClosedTabs, ...filteredHistoryTabs];
 }
 
 function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -1,0 +1,33 @@
+import { getFilteredSuggestions, objectFromArray } from 'lib/utils.js';
+import tabSuggestions from './tab.js';
+import closedTabSuggestions from './closedTab.js';
+
+async function allRecentlyViewedSuggestions(searchString) {
+  const tabs = await tabSuggestions(searchString);
+  const closedTabs = await closedTabSuggestions(searchString);
+  console.warn('Tabs: ', tabs);
+  console.warn('Closed Tabs: ', closedTabs);
+
+  const recentlyViewed = new Set(tabs);
+  closedTabs.forEach(tab => {
+    recentlyViewed.add(tab);
+  });
+
+  console.warn('Recent: ', recentlyViewed);
+
+  return recentlyViewed;
+}
+
+export default async function recentlyViewedSuggestions(searchString) {
+  //   const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
+
+  //   if (searchString && sakaSettings.enableFuzzySearch) {
+  //     return getFilteredSuggestions(
+  //       searchString,
+  //       allRecentlyViewedSuggestions,
+  //       1
+  //     );
+  //   }
+
+  return allRecentlyViewedSuggestions(searchString);
+}

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -8,17 +8,14 @@ async function allRecentlyViewedSuggestions(searchString) {
   const closedTabs = await getAllClosedTabs(searchString);
   const historyTabs = await getAllHistoryTabs(searchString);
 
-  const openTabsMap = objectFromArray(openTabs, 'url');
-  const filteredClosedTabs = closedTabs.filter(
-    tab => !openTabsMap.hasOwnProperty(tab.url)
+  const filteredClosedTabs = closedTabs.filter(tab =>
+    openTabs.every(openTab => openTab.url !== tab.url)
   );
 
-  const openAndClosedTabsMap = objectFromArray(
-    [...openTabs, ...filteredClosedTabs],
-    'url'
-  );
-  const filteredHistoryTabs = historyTabs.filter(
-    tab => !openAndClosedTabsMap.hasOwnProperty(tab.url)
+  const filteredHistoryTabs = historyTabs.filter(tab =>
+    [...openTabs, ...filteredClosedTabs].every(
+      openOrClosedTab => openOrClosedTab.url !== tab.url
+    )
   );
 
   return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs].map(

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -33,14 +33,24 @@ function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
 async function filteredRecentlyViewedSuggestions(searchString) {
   const tabs = await allTabSuggestions();
   const closedTabs = await getAllClosedTabs(searchString);
+  const historyTabs = await getAllHistoryTabs(searchString);
 
-  return [...tabs, ...Object.values(closedTabs)];
+  console.warn('Filtered: ', [
+    ...tabs,
+    ...Object.values(closedTabs),
+    ...Object.values(historyTabs)
+  ]);
+  return [
+    ...tabs,
+    ...Object.values(closedTabs),
+    ...Object.values(historyTabs)
+  ].map(tab => ({ ...tab, originalType: tab.type, type: 'recentlyViewed' }));
 }
 
 export default async function recentlyViewedSuggestions(searchString) {
-  const suggestions = await allRecentlyViewedSuggestions(searchString);
-
   if (searchString === '') {
+    const suggestions = await allRecentlyViewedSuggestions(searchString);
+    console.warn('Suggestions: ', suggestions);
     return suggestions.sort(compareRecentlyViewedSuggestions);
   }
 

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -8,22 +8,6 @@ async function allRecentlyViewedSuggestions(searchString) {
   const closedTabs = await getAllClosedTabs(searchString);
   const historyTabs = await getAllHistoryTabs(searchString);
 
-  // const closedTabsMap = objectFromArray(closedTabs, 'url');
-  // const historyTabsMap = objectFromArray(historyTabs, 'url');
-
-  // const recentOpenTabs = openTabs.map(openTab => {
-  //   if (closedTabsMap[openTab.url]) {
-  //     delete closedTabsMap[openTab.url];
-  //   }
-  //   return openTab;
-  // });
-
-  // return [...recentOpenTabs, ...Object.values(closedTabsMap)];
-
-  console.error('Tabs: ', openTabs);
-  console.error('Closed: ', closedTabs);
-  console.error('History: ', historyTabs);
-
   const openTabsMap = objectFromArray(openTabs, 'url');
   const filteredClosedTabs = closedTabs.filter(
     tab => !openTabsMap.hasOwnProperty(tab.url)
@@ -37,11 +21,6 @@ async function allRecentlyViewedSuggestions(searchString) {
     tab => !openAndClosedTabsMap.hasOwnProperty(tab.url)
   );
 
-  console.warn('Recent: ', [
-    ...openTabs,
-    ...filteredClosedTabs,
-    ...filteredHistoryTabs
-  ]);
   return [...openTabs, ...filteredClosedTabs, ...filteredHistoryTabs];
 }
 
@@ -59,11 +38,7 @@ async function filteredRecentlyViewedSuggestions(searchString) {
 export default async function recentlyViewedSuggestions(searchString) {
   const suggestions = await allRecentlyViewedSuggestions(searchString);
 
-  if (searchString !== undefined) {
-    console.warn(
-      'Sorted: ',
-      suggestions.sort(compareRecentlyViewedSuggestions)
-    );
+  if (searchString === '') {
     return suggestions.sort(compareRecentlyViewedSuggestions);
   }
 

--- a/src/suggestion_engine/server/providers/recentlyViewed.js
+++ b/src/suggestion_engine/server/providers/recentlyViewed.js
@@ -19,7 +19,7 @@ async function allRecentlyViewedSuggestions(searchString) {
 }
 
 function compareRecentlyViewedSuggestions(suggestion1, suggestion2) {
-  return suggestion1.lastAccessed - suggestion2.lastAccessed;
+  return suggestion2.lastAccessed - suggestion1.lastAccessed;
 }
 
 export default async function recentlyViewedSuggestions(searchString) {

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -28,20 +28,18 @@ export async function allTabSuggestions() {
 async function recentTabSuggestions() {
   const tabs = await allTabSuggestions();
   const tabsMap = objectFromArray(tabs, 'tabId');
-  console.warn('TypeOf tabsMap: ', typeof Object.values(tabsMap));
-  console.warn('tabsMap: ', Object.values(tabsMap));
-  console.warn('tabsMap spread: ', ...Object.values(tabsMap));
   const { tabHistory } = await browser.runtime.getBackgroundPage();
   const recentTabs = tabHistory.map(tabId => {
     const tab = tabsMap[tabId];
     delete tabsMap[tabId];
     return tab;
   });
-  console.warn('final: ', [...recentTabs, ...Object.values(tabsMap)]);
   return [...recentTabs, ...Object.values(tabsMap)];
 }
 
 export default async function tabSuggestions(searchString) {
+  console.log('Tab Search: ', searchString);
+
   return searchString === ''
     ? recentTabSuggestions()
     : getFilteredSuggestions(searchString, {

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -27,6 +27,7 @@ export async function allTabSuggestions() {
 async function recentTabSuggestions() {
   const tabs = await allTabSuggestions();
   const tabsMap = objectFromArray(tabs, 'tabId');
+  console.log('ASD: ', await browser.runtime.getBackgroundPage());
   const { tabHistory } = await browser.runtime.getBackgroundPage();
 
   const recentTabs = tabHistory.map(recentlyUsedTab => {

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -28,6 +28,7 @@ async function recentTabSuggestions() {
   const tabs = await allTabSuggestions();
   const tabsMap = objectFromArray(tabs, 'tabId');
   const { tabHistory } = await browser.runtime.getBackgroundPage();
+
   const recentTabs = tabHistory.map(tabId => {
     const tab = tabsMap[tabId];
     delete tabsMap[tabId];

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -29,12 +29,28 @@ async function recentTabSuggestions() {
   const tabsMap = objectFromArray(tabs, 'tabId');
   const { tabHistory } = await browser.runtime.getBackgroundPage();
 
-  const recentTabs = tabHistory.map(tabId => {
-    const tab = tabsMap[tabId];
-    delete tabsMap[tabId];
-    return tab;
+  const recentTabs = tabHistory.map(recentlyUsedTab => {
+    const tab = tabsMap[recentlyUsedTab.tabId];
+    delete tabsMap[recentlyUsedTab.tabId];
+    return { ...tab, lastAccessed: recentlyUsedTab.lastAccessed };
   });
+
   return [...recentTabs, ...Object.values(tabsMap)];
+}
+
+// TODO: Remove this once chrome tab API provides recently viewed
+export async function recentVisitedTabSuggestions() {
+  const tabs = await allTabSuggestions();
+  const tabsMap = objectFromArray(tabs, 'tabId');
+  const { tabHistory } = await browser.runtime.getBackgroundPage();
+
+  const recentTabs = tabHistory.map(recentlyUsedTab => {
+    const tab = tabsMap[recentlyUsedTab.tabId];
+    delete tabsMap[recentlyUsedTab.tabId];
+    return { ...tab, lastAccessed: recentlyUsedTab.lastAccessed };
+  });
+
+  return [...recentTabs];
 }
 
 export default async function tabSuggestions(searchString) {

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -19,7 +19,7 @@ export async function allTabSuggestions() {
       url,
       favIconUrl: incognito ? null : favIconUrl,
       incognito,
-      lastAccessed
+      lastAccessed: lastAccessed * 0.001
     })
   );
 }
@@ -27,7 +27,6 @@ export async function allTabSuggestions() {
 async function recentTabSuggestions() {
   const tabs = await allTabSuggestions();
   const tabsMap = objectFromArray(tabs, 'tabId');
-  console.log('ASD: ', await browser.runtime.getBackgroundPage());
   const { tabHistory } = await browser.runtime.getBackgroundPage();
 
   const recentTabs = tabHistory.map(recentlyUsedTab => {
@@ -48,7 +47,7 @@ export async function recentVisitedTabSuggestions() {
   const recentTabs = tabHistory.map(recentlyUsedTab => {
     const tab = tabsMap[recentlyUsedTab.tabId];
     delete tabsMap[recentlyUsedTab.tabId];
-    return { ...tab, lastAccessed: recentlyUsedTab.lastAccessed };
+    return { ...tab, lastAccessed: recentlyUsedTab.lastAccessed * 0.001 };
   });
 
   return [...recentTabs];

--- a/src/suggestion_engine/server/providers/tab.js
+++ b/src/suggestion_engine/server/providers/tab.js
@@ -2,7 +2,6 @@ import { getFilteredSuggestions, objectFromArray } from 'lib/utils.js';
 
 export async function allTabSuggestions() {
   const tabs = await browser.tabs.query({});
-  console.error(tabs);
   return tabs.map(
     ({
       id: tabId,
@@ -38,8 +37,6 @@ async function recentTabSuggestions() {
 }
 
 export default async function tabSuggestions(searchString) {
-  console.log('Tab Search: ', searchString);
-
   return searchString === ''
     ? recentTabSuggestions()
     : getFilteredSuggestions(searchString, {

--- a/src/suggestion_utils/index.js
+++ b/src/suggestion_utils/index.js
@@ -5,7 +5,7 @@ export const icons = {
   tab: 'tab',
   closedTab: 'restore_page',
   history: 'history',
-  recentlyViewed: 'recently_viewed',
+  recentlyViewed: 'history',
   bookmark: 'bookmark_border',
   incognito: 'visibility_off'
 };

--- a/src/suggestion_utils/index.js
+++ b/src/suggestion_utils/index.js
@@ -5,6 +5,7 @@ export const icons = {
   tab: 'tab',
   closedTab: 'restore_page',
   history: 'history',
+  recentlyViewed: 'recently_viewed',
   bookmark: 'bookmark_border',
   incognito: 'visibility_off'
 };
@@ -38,6 +39,14 @@ export function preprocessSuggestion(suggestion, searchText) {
       };
     }
     case 'history': {
+      const prettyURL = prettifyURL(suggestion.url, searchText);
+      return {
+        ...suggestion,
+        prettyURL,
+        text: prettyURL
+      };
+    }
+    case 'recentlyViewed': {
       const prettyURL = prettifyURL(suggestion.url, searchText);
       return {
         ...suggestion,

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Saka",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "author": "Sufyan Dawoodjee, Uzair Shamim",
   "description": "Saka - elegent tab search, selection, and beyond",
   "manifest_version": 2,

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -50,7 +50,7 @@ describe('lib/util ', () => {
   describe('getFilteredSuggestions ', () => {
     it('should only return valid matches to search string', async () => {
       const searchString = 'hello';
-      const getSuggestions = function(searchString) {
+      const getSuggestions = function() {
         return [
           {
             title: 'Hello',
@@ -85,10 +85,11 @@ describe('lib/util ', () => {
         }
       ];
 
-      const results = await libUtil.getFilteredSuggestions(
-        searchString,
-        getSuggestions
-      );
+      const results = await libUtil.getFilteredSuggestions(searchString, {
+        getSuggestions,
+        threshold: 0.6,
+        keys: ['title', 'url']
+      });
       expect(results).toEqual(expectedResults);
     });
   });

--- a/test/suggestion_engine/providers/closedTab.test.js
+++ b/test/suggestion_engine/providers/closedTab.test.js
@@ -2,7 +2,7 @@ const browser = require('sinon-chrome/webextensions');
 
 import closedTabSuggestions from 'suggestion_engine/server/providers/closedTab.js';
 
-describe('server/providers/bookmark ', () => {
+describe('server/providers/closedTabs ', () => {
   beforeAll(() => {
     global.browser = browser;
   });
@@ -15,6 +15,7 @@ describe('server/providers/bookmark ', () => {
     it('should return all closed tabs when no search string provided', async () => {
       const queryResults = [
         {
+          lastModified: 123456,
           tab: {
             id: 1,
             windowId: 0,
@@ -34,7 +35,8 @@ describe('server/providers/bookmark ', () => {
           favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
           sessionId: undefined,
           score: undefined,
-          incognito: false
+          incognito: false,
+          lastAccessed: 123456
         }
       ];
 
@@ -48,6 +50,7 @@ describe('server/providers/bookmark ', () => {
     it('should filter out entries for saka in recently closed tabs', async () => {
       const queryResults = [
         {
+          lastModified: 123456,
           tab: {
             id: 1,
             windowId: 0,
@@ -58,6 +61,7 @@ describe('server/providers/bookmark ', () => {
           }
         },
         {
+          lastModified: 654321,
           tab: {
             id: 2,
             windowId: 0,
@@ -77,7 +81,8 @@ describe('server/providers/bookmark ', () => {
           favIconUrl: null,
           sessionId: undefined,
           score: undefined,
-          incognito: true
+          incognito: true,
+          lastAccessed: 123456
         }
       ];
 
@@ -91,6 +96,7 @@ describe('server/providers/bookmark ', () => {
     it('should return all closed tabs matching searchString', async () => {
       const queryResults = [
         {
+          lastModified: 123456,
           tab: {
             id: 1,
             windowId: 0,
@@ -101,6 +107,7 @@ describe('server/providers/bookmark ', () => {
           }
         },
         {
+          lastModified: 654321,
           tab: {
             id: 2,
             windowId: 0,
@@ -121,6 +128,7 @@ describe('server/providers/bookmark ', () => {
           sessionId: undefined,
           score: undefined,
           incognito: true,
+          lastAccessed: 654321,
           matches: [
             {
               indices: [[0, 3]],

--- a/test/suggestion_engine/providers/history.test.js
+++ b/test/suggestion_engine/providers/history.test.js
@@ -41,14 +41,14 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastVisitTime: 1524795334,
+          lastAccessed: 1524795334,
           score: 15
         },
         {
           type: 'history',
           title: 'Example',
           url: 'https://example.com',
-          lastVisitTime: 1524794200,
+          lastAccessed: 1524794200,
           score: 1
         }
       ];
@@ -90,7 +90,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastVisitTime: 1524795334,
+          lastAccessed: 1524795334,
           score: undefined,
           matches: [
             {
@@ -111,7 +111,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           title: 'Example',
           url: 'https://example.com',
-          lastVisitTime: 1524794200,
+          lastAccessed: 1524794200,
           score: undefined,
           matches: [
             {
@@ -167,7 +167,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastVisitTime: 1524795334,
+          lastAccessed: 1524795334,
           score: 15
         }
       ];

--- a/test/suggestion_engine/providers/history.test.js
+++ b/test/suggestion_engine/providers/history.test.js
@@ -41,14 +41,14 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastAccessed: 1524795334,
+          lastAccessed: 1524795.334,
           score: 15
         },
         {
           type: 'history',
           title: 'Example',
           url: 'https://example.com',
-          lastAccessed: 1524794200,
+          lastAccessed: 1524794.2,
           score: 1
         }
       ];
@@ -91,7 +91,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastAccessed: 1524795334,
+          lastAccessed: 1524795.334,
           score: undefined,
           matches: [
             {
@@ -112,7 +112,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           title: 'Example',
           url: 'https://example.com',
-          lastAccessed: 1524794200,
+          lastAccessed: 1524794.2,
           score: undefined,
           matches: [
             {
@@ -168,7 +168,7 @@ describe('server/providers/history ', () => {
           type: 'history',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastAccessed: 1524795334,
+          lastAccessed: 1524795.334,
           score: 15
         }
       ];

--- a/test/suggestion_engine/providers/mode.test.js
+++ b/test/suggestion_engine/providers/mode.test.js
@@ -41,6 +41,15 @@ describe('server/providers/mode ', () => {
           color: colorMap.history,
           fadedColor: fadedColorMap.history,
           icon: 'history'
+        },
+        {
+          type: 'mode',
+          label: 'Recently Viewed',
+          mode: 'recentlyViewed',
+          shortcut: `${ctrlChar}-shift-x`,
+          color: colorMap.recentlyViewed,
+          fadedColor: fadedColorMap.recentlyViewed,
+          icon: 'timelapse'
         }
       ];
 
@@ -63,6 +72,24 @@ describe('server/providers/mode ', () => {
             {
               indices: [[2, 2], [6, 6], [9, 10]],
               value: 'Recently Closed Tabs',
+              key: 'label',
+              arrayIndex: 0
+            }
+          ]
+        },
+        {
+          type: 'mode',
+          label: 'Recently Viewed',
+          mode: 'recentlyViewed',
+          shortcut: `${ctrlChar}-shift-x`,
+          color: 'rgba(152,78,163,1)',
+          fadedColor: 'rgba(152,78,163,0.44)',
+          icon: 'timelapse',
+          score: undefined,
+          matches: [
+            {
+              indices: [[2, 2], [6, 6]],
+              value: 'Recently Viewed',
               key: 'label',
               arrayIndex: 0
             }

--- a/test/suggestion_engine/providers/recentlyViewed.test.js
+++ b/test/suggestion_engine/providers/recentlyViewed.test.js
@@ -13,7 +13,12 @@ describe('server/providers/recentlyViewed ', () => {
 
   describe('recentlyViewedSuggestions ', () => {
     it('should return all recently viewed tabs when search string is empty', async () => {
-      const tabHistory = { tabHistory: [1] };
+      const tabHistory = {
+        tabHistory: [
+          { tabId: 1, lastAccessed: 123456 },
+          { tabId: 0, lastAccessed: 654321 }
+        ]
+      };
       const tabResults = [
         {
           id: 1,
@@ -234,32 +239,6 @@ describe('server/providers/recentlyViewed ', () => {
               arrayIndex: 0
             })
           ]
-        },
-        {
-          type: 'recentlyViewed',
-          tabId: 1,
-          title: 'Saka',
-          url: 'https://github.com/lusakasa/saka',
-          favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
-          incognito: false,
-          lastAccessed: 123456,
-          originalType: 'closedTab',
-          matches: [
-            Object({
-              indices: [[0, 3]],
-              value: 'Saka',
-              key: 'title',
-              arrayIndex: 0
-            }),
-            Object({
-              indices: [[4, 4], [21, 24]],
-              value: 'https://github.com/lusakasa/saka',
-              key: 'url',
-              arrayIndex: 0
-            })
-          ],
-          sessionId: 'abc123',
-          score: undefined
         },
         {
           type: 'recentlyViewed',

--- a/test/suggestion_engine/providers/recentlyViewed.test.js
+++ b/test/suggestion_engine/providers/recentlyViewed.test.js
@@ -143,7 +143,6 @@ describe('server/providers/recentlyViewed ', () => {
       browser.runtime.getBackgroundPage.returns(trackedHistory);
       browser.sessions.getRecentlyClosed.returns(recentlyClosedResults);
       browser.history.search.returns(historyResults);
-      //   browser.storage.sync.get.returns(settingsStore);
       expect(await recentlyViewedSuggestions(searchString)).toEqual(
         expectedResult
       );

--- a/test/suggestion_engine/providers/recentlyViewed.test.js
+++ b/test/suggestion_engine/providers/recentlyViewed.test.js
@@ -13,12 +13,17 @@ describe('server/providers/recentlyViewed ', () => {
 
   describe('recentlyViewedSuggestions ', () => {
     it('should return all recently viewed tabs when search string is empty', async () => {
-      const tabHistory = {
+      const trackedHistory = {
         tabHistory: [
           { tabId: 1, lastAccessed: 123456 },
           { tabId: 0, lastAccessed: 654321 }
+        ],
+        recentlyClosed: [
+          { tab: { tabId: 1, lastAccessed: 111111 } },
+          { tab: { tabId: 4, lastAccessed: 222222 } }
         ]
       };
+
       const tabResults = [
         {
           id: 1,
@@ -91,9 +96,21 @@ describe('server/providers/recentlyViewed ', () => {
           type: 'recentlyViewed',
           url: 'https://example.com',
           title: 'Example',
-          lastAccessed: 1524794200,
+          lastAccessed: 1524794.2,
           score: 1,
           originalType: 'history'
+        },
+        {
+          lastAccessed: 19191,
+          tabId: 2,
+          title: 'Recently Viewed Mode',
+          url: 'https://github.com/lusakasa/saka/pull/45',
+          favIconUrl: null,
+          incognito: true,
+          sessionId: '123abc',
+          score: undefined,
+          type: 'recentlyViewed',
+          originalType: 'closedTab'
         },
         {
           type: 'recentlyViewed',
@@ -103,7 +120,7 @@ describe('server/providers/recentlyViewed ', () => {
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: null,
           incognito: true,
-          lastAccessed: 654321,
+          lastAccessed: 654.321,
           originalType: 'tab'
         },
         {
@@ -114,20 +131,8 @@ describe('server/providers/recentlyViewed ', () => {
           url: 'https://google.com',
           favIconUrl: 'https://google.com/icon.png',
           incognito: false,
-          lastAccessed: 123456,
+          lastAccessed: 123.456,
           originalType: 'tab'
-        },
-        {
-          type: 'recentlyViewed',
-          tabId: 2,
-          title: 'Recently Viewed Mode',
-          url: 'https://github.com/lusakasa/saka/pull/45',
-          favIconUrl: null,
-          incognito: true,
-          lastAccessed: 19191,
-          sessionId: '123abc',
-          score: undefined,
-          originalType: 'closedTab'
         }
       ];
 
@@ -135,7 +140,7 @@ describe('server/providers/recentlyViewed ', () => {
       const sakaId = 'abcdefg/saka.html';
       browser.tabs.query.returns(tabResults);
       browser.runtime.getURL.returns(sakaId);
-      browser.runtime.getBackgroundPage.returns(tabHistory);
+      browser.runtime.getBackgroundPage.returns(trackedHistory);
       browser.sessions.getRecentlyClosed.returns(recentlyClosedResults);
       browser.history.search.returns(historyResults);
       //   browser.storage.sync.get.returns(settingsStore);
@@ -222,7 +227,7 @@ describe('server/providers/recentlyViewed ', () => {
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: null,
           incognito: true,
-          lastAccessed: 654321,
+          lastAccessed: 654.321,
           originalType: 'tab',
           score: undefined,
           matches: [
@@ -244,7 +249,7 @@ describe('server/providers/recentlyViewed ', () => {
           type: 'recentlyViewed',
           url: 'https://github.com/lusakasa/saka',
           title: 'Saka Github',
-          lastAccessed: 1524795334,
+          lastAccessed: 1524795.334,
           score: undefined,
           originalType: 'history',
           matches: [

--- a/test/suggestion_engine/providers/recentlyViewed.test.js
+++ b/test/suggestion_engine/providers/recentlyViewed.test.js
@@ -1,0 +1,147 @@
+const browser = require('sinon-chrome/webextensions');
+
+import recentlyViewedSuggestions from 'suggestion_engine/server/providers/recentlyViewed.js';
+
+describe('server/providers/recentlyViewed ', () => {
+  beforeAll(() => {
+    global.browser = browser;
+  });
+
+  beforeEach(() => {
+    browser.flush();
+  });
+
+  describe('recentlyViewedSuggestions ', () => {
+    it('should return all recently viewed tabs when search string is empty', async () => {
+      const tabHistory = { tabHistory: [1] };
+      const tabResults = [
+        {
+          id: 1,
+          windowId: 0,
+          title: 'Google',
+          url: 'https://google.com',
+          favIconUrl: 'https://google.com/icon.png',
+          incognito: false,
+          lastAccessed: 123456
+        },
+        {
+          id: 0,
+          windowId: 0,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
+          incognito: true,
+          lastAccessed: 654321
+        }
+      ];
+
+      const recentlyClosedResults = [
+        {
+          lastModified: 123456,
+          tab: {
+            id: 1,
+            windowId: 0,
+            title: 'Saka',
+            url: 'https://github.com/lusakasa/saka',
+            favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
+            incognito: false,
+            sessionId: 'abc123'
+          }
+        },
+        {
+          lastModified: 19191,
+          tab: {
+            id: 2,
+            windowId: 0,
+            title: 'Recently Viewed Mode',
+            url: 'https://github.com/lusakasa/saka/pull/45',
+            favIconUrl: 'https://github.com/icon.png',
+            incognito: true,
+            sessionId: '123abc'
+          }
+        }
+      ];
+
+      const historyResults = [
+        {
+          id: 1,
+          url: 'https://github.com/lusakasa/saka',
+          title: 'Saka Github',
+          lastVisitTime: 1524795334,
+          visitCount: 5,
+          typedCount: 10
+        },
+        {
+          id: 3,
+          url: 'https://example.com',
+          title: 'Example',
+          lastVisitTime: 1524794200,
+          visitCount: 1,
+          typedCount: 0
+        }
+      ];
+
+      const expectedResult = [
+        {
+          type: 'recentlyViewed',
+          url: 'https://example.com',
+          title: 'Example',
+          lastAccessed: 1524794200,
+          score: 1,
+          originalType: 'history'
+        },
+        {
+          type: 'recentlyViewed',
+          tabId: 0,
+          windowId: 0,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: null,
+          incognito: true,
+          lastAccessed: 654321,
+          originalType: 'tab'
+        },
+        {
+          type: 'recentlyViewed',
+          tabId: 1,
+          windowId: 0,
+          title: 'Google',
+          url: 'https://google.com',
+          favIconUrl: 'https://google.com/icon.png',
+          incognito: false,
+          lastAccessed: 123456,
+          originalType: 'tab'
+        },
+        {
+          type: 'recentlyViewed',
+          tabId: 2,
+          title: 'Recently Viewed Mode',
+          url: 'https://github.com/lusakasa/saka/pull/45',
+          favIconUrl: null,
+          incognito: true,
+          lastAccessed: 19191,
+          sessionId: '123abc',
+          score: undefined,
+          originalType: 'closedTab'
+        }
+      ];
+
+      const searchString = '';
+      const sakaId = 'abcdefg/saka.html';
+      browser.tabs.query.returns(tabResults);
+      browser.runtime.getURL.returns(sakaId);
+      browser.runtime.getBackgroundPage.returns(tabHistory);
+      browser.sessions.getRecentlyClosed.returns(recentlyClosedResults);
+      browser.history.search.returns(historyResults);
+      //   browser.storage.sync.get.returns(settingsStore);
+      expect(await recentlyViewedSuggestions(searchString)).toEqual(
+        expectedResult
+      );
+    });
+  });
+
+  afterAll(() => {
+    browser.flush();
+    delete global.browser;
+  });
+});

--- a/test/suggestion_engine/providers/recentlyViewed.test.js
+++ b/test/suggestion_engine/providers/recentlyViewed.test.js
@@ -138,6 +138,184 @@ describe('server/providers/recentlyViewed ', () => {
         expectedResult
       );
     });
+
+    it('should return matching recently viewed tabs when search string is not empty', async () => {
+      const tabHistory = { tabHistory: [0] };
+      const tabResults = [
+        {
+          id: 1,
+          windowId: 0,
+          title: 'Google',
+          url: 'https://google.com',
+          favIconUrl: 'https://google.com/icon.png',
+          incognito: false,
+          lastAccessed: 123456
+        },
+        {
+          id: 0,
+          windowId: 0,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
+          incognito: true,
+          lastAccessed: 654321
+        }
+      ];
+
+      const recentlyClosedResults = [
+        {
+          lastModified: 123456,
+          tab: {
+            id: 1,
+            windowId: 0,
+            title: 'Saka',
+            url: 'https://github.com/lusakasa/saka',
+            favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
+            incognito: false,
+            sessionId: 'abc123'
+          }
+        },
+        {
+          lastModified: 19191,
+          tab: {
+            id: 2,
+            windowId: 0,
+            title: 'Recently Viewed Mode',
+            url: 'https://github.com/lusakasa/saka/pull/45',
+            favIconUrl: 'https://github.com/icon.png',
+            incognito: true,
+            sessionId: '123abc'
+          }
+        }
+      ];
+
+      const historyResults = [
+        {
+          id: 1,
+          url: 'https://github.com/lusakasa/saka',
+          title: 'Saka Github',
+          lastVisitTime: 1524795334,
+          visitCount: 5,
+          typedCount: 10
+        },
+        {
+          id: 3,
+          url: 'https://example.com',
+          title: 'Example',
+          lastVisitTime: 1524794200,
+          visitCount: 1,
+          typedCount: 0
+        }
+      ];
+
+      const expectedResult = [
+        {
+          type: 'recentlyViewed',
+          tabId: 0,
+          windowId: 0,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: null,
+          incognito: true,
+          lastAccessed: 654321,
+          originalType: 'tab',
+          score: undefined,
+          matches: [
+            Object({
+              indices: [[0, 3]],
+              value: 'Saka',
+              key: 'title',
+              arrayIndex: 0
+            }),
+            Object({
+              indices: [[4, 4], [21, 24]],
+              value: 'https://github.com/lusakasa/saka',
+              key: 'url',
+              arrayIndex: 0
+            })
+          ]
+        },
+        {
+          type: 'recentlyViewed',
+          tabId: 1,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
+          incognito: false,
+          lastAccessed: 123456,
+          originalType: 'closedTab',
+          matches: [
+            Object({
+              indices: [[0, 3]],
+              value: 'Saka',
+              key: 'title',
+              arrayIndex: 0
+            }),
+            Object({
+              indices: [[4, 4], [21, 24]],
+              value: 'https://github.com/lusakasa/saka',
+              key: 'url',
+              arrayIndex: 0
+            })
+          ],
+          sessionId: 'abc123',
+          score: undefined
+        },
+        {
+          type: 'recentlyViewed',
+          url: 'https://github.com/lusakasa/saka',
+          title: 'Saka Github',
+          lastAccessed: 1524795334,
+          score: undefined,
+          originalType: 'history',
+          matches: [
+            Object({
+              indices: [[0, 3]],
+              value: 'Saka Github',
+              key: 'title',
+              arrayIndex: 0
+            }),
+            Object({
+              indices: [[4, 4], [21, 24]],
+              value: 'https://github.com/lusakasa/saka',
+              key: 'url',
+              arrayIndex: 0
+            })
+          ]
+        },
+        {
+          type: 'recentlyViewed',
+          tabId: 2,
+          title: 'Recently Viewed Mode',
+          url: 'https://github.com/lusakasa/saka/pull/45',
+          favIconUrl: null,
+          incognito: true,
+          lastAccessed: 19191,
+          sessionId: '123abc',
+          score: undefined,
+          originalType: 'closedTab',
+          matches: [
+            Object({
+              indices: [[4, 4], [21, 24]],
+              value: 'https://github.com/lusakasa/saka/pull/45',
+              key: 'url',
+              arrayIndex: 0
+            })
+          ]
+        }
+      ];
+
+      const searchString = 'saka';
+      const sakaId = 'abcdefg/saka.html';
+      browser.tabs.query.returns(tabResults);
+      browser.runtime.getURL.returns(sakaId);
+      browser.runtime.getBackgroundPage.returns(tabHistory);
+      browser.sessions.getRecentlyClosed.returns(recentlyClosedResults);
+      browser.history.search.returns(historyResults);
+      expect(await recentlyViewedSuggestions(searchString)).toEqual(
+        expectedResult
+      );
+    });
   });
 
   afterAll(() => {

--- a/test/suggestion_engine/providers/tab.test.js
+++ b/test/suggestion_engine/providers/tab.test.js
@@ -20,7 +20,8 @@ describe('server/providers/tab ', () => {
           title: 'Google',
           url: 'https://google.com',
           favIconUrl: 'https://google.com/icon.png',
-          incognito: false
+          incognito: false,
+          lastAccessed: 123456
         },
         {
           id: 0,
@@ -28,7 +29,8 @@ describe('server/providers/tab ', () => {
           title: 'Saka',
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
-          incognito: true
+          incognito: true,
+          lastAccessed: 654321
         }
       ];
 
@@ -55,7 +57,8 @@ describe('server/providers/tab ', () => {
           title: 'Saka',
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: null,
-          incognito: true
+          incognito: true,
+          lastAccessed: 654321
         },
         {
           type: 'tab',
@@ -64,7 +67,8 @@ describe('server/providers/tab ', () => {
           title: 'Google',
           url: 'https://google.com',
           favIconUrl: 'https://google.com/icon.png',
-          incognito: false
+          incognito: false,
+          lastAccessed: 123456
         }
       ];
 
@@ -82,7 +86,8 @@ describe('server/providers/tab ', () => {
           title: 'Saka',
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
-          incognito: false
+          incognito: false,
+          lastAccessed: 123456
         },
         {
           id: 0,
@@ -90,7 +95,8 @@ describe('server/providers/tab ', () => {
           title: 'Google',
           url: 'https://google.com',
           favIconUrl: 'https://google.com/icon.png',
-          incognito: false
+          incognito: false,
+          lastAccessed: 654321
         }
       ];
 
@@ -103,6 +109,7 @@ describe('server/providers/tab ', () => {
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
           incognito: false,
+          lastAccessed: 123456,
           matches: [
             {
               indices: [[0, 3]],

--- a/test/suggestion_engine/providers/tab.test.js
+++ b/test/suggestion_engine/providers/tab.test.js
@@ -101,7 +101,7 @@ describe('server/providers/tab ', () => {
           url: 'https://github.com/lusakasa/saka',
           favIconUrl: 'https://github.com/lusakasa/saka/icon.png',
           incognito: false,
-          lastAccessed: 123456,
+          lastAccessed: 123.456,
           matches: [
             {
               indices: [[0, 3]],

--- a/test/suggestion_engine/providers/tab.test.js
+++ b/test/suggestion_engine/providers/tab.test.js
@@ -34,32 +34,9 @@ describe('server/providers/tab ', () => {
         }
       ];
 
-      const tabHistory = {
-        tabHistory: [
-          {
-            type: 'tab',
-            tabId: 1,
-            windowId: 0,
-            title: 'Google',
-            url: 'https://google.com',
-            favIconUrl: 'https://google.com/icon.png',
-            incognito: false
-          }
-        ]
-      };
+      const tabHistory = { tabHistory: [1] };
 
       const expectedResult = [
-        undefined,
-        {
-          type: 'tab',
-          tabId: 0,
-          windowId: 0,
-          title: 'Saka',
-          url: 'https://github.com/lusakasa/saka',
-          favIconUrl: null,
-          incognito: true,
-          lastAccessed: 654321
-        },
         {
           type: 'tab',
           tabId: 1,
@@ -69,6 +46,16 @@ describe('server/providers/tab ', () => {
           favIconUrl: 'https://google.com/icon.png',
           incognito: false,
           lastAccessed: 123456
+        },
+        {
+          type: 'tab',
+          tabId: 0,
+          windowId: 0,
+          title: 'Saka',
+          url: 'https://github.com/lusakasa/saka',
+          favIconUrl: null,
+          incognito: true,
+          lastAccessed: 654321
         }
       ];
 

--- a/test/suggestion_engine/providers/tab.test.js
+++ b/test/suggestion_engine/providers/tab.test.js
@@ -34,7 +34,12 @@ describe('server/providers/tab ', () => {
         }
       ];
 
-      const tabHistory = { tabHistory: [1] };
+      const tabHistory = {
+        tabHistory: [
+          { tabId: 1, lastAccessed: 123456 },
+          { tabId: 0, lastAccessed: 654321 }
+        ]
+      };
 
       const expectedResult = [
         {


### PR DESCRIPTION
Added a recently viewed tabs mode that displays all tabs recently visited sorted by last visited timestamp.

### How it works
- Fetch all open tabs
- Fetch all recently closed tabs, if any of these match the open tabs discard them and keep the open tab
- Combine the open and recently closed tabs
- Fetch all tab history, if any of these match tabs in the list created above, filter them out
- Create a new list with open tabs, recently closed tabs, tab history
- Sort the list based on timestamp and then return

### TODO
- [x] Fix missing favicon in suggestions
- [x] Refactor code to use smaller functions
- [x] Add tests
- [x] Version bump
- [x] Fix Chrome Support
- [x] Add to modes

Resolves #27