### PR TITLE
Fixed missing settings in history and bookmark provider

### DIFF
--- a/src/suggestion_engine/server/providers/bookmark.js
+++ b/src/suggestion_engine/server/providers/bookmark.js
@@ -24,8 +24,10 @@ async function allBookmarkSuggestions(searchText) {
 
 export default async function bookmarkSuggestions(searchString) {
   const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
-
-  if (searchString && sakaSettings.enableFuzzySearch) {
+  const enableFuzzySearch = sakaSettings
+    ? sakaSettings.enableFuzzySearch
+    : true;
+  if (searchString && enableFuzzySearch) {
     return getFilteredSuggestions(searchString, allBookmarkSuggestions, 1);
   }
 

--- a/src/suggestion_engine/server/providers/history.js
+++ b/src/suggestion_engine/server/providers/history.js
@@ -26,8 +26,10 @@ async function allHistorySuggestions(searchText) {
 
 export default async function historySuggestions(searchString) {
   const { sakaSettings } = await browser.storage.sync.get(['sakaSettings']);
-
-  if (searchString && sakaSettings.enableFuzzySearch) {
+  const enableFuzzySearch = sakaSettings
+    ? sakaSettings.enableFuzzySearch
+    : true;
+  if (searchString && enableFuzzySearch) {
     return getFilteredSuggestions(searchString, allHistorySuggestions, 1);
   }
 


### PR DESCRIPTION
Fixed a bug that caused saka to not load history or bookmark mode when the settings were missing from the browser storage.