### PR TITLE
Fixes messaging issue with saka key

### DIFF
--- a/src/background_page/index.js
+++ b/src/background_page/index.js
@@ -109,11 +109,11 @@ async function saveSettings(searchHistory) {
   await browser.storage.sync.set({ searchHistory: [...searchHistory] });
 }
 
-chrome.browserAction.onClicked.addListener(() => {
+browser.browserAction.onClicked.addListener(() => {
   toggleSaka();
 });
 
-chrome.commands.onCommand.addListener(command => {
+browser.commands.onCommand.addListener(command => {
   switch (command) {
     case 'toggleSaka':
     case 'toggleSaka2':
@@ -126,7 +126,7 @@ chrome.commands.onCommand.addListener(command => {
   }
 });
 
-chrome.runtime.onMessage.addListener(async (message, sender) => {
+browser.runtime.onMessage.addListener(async (message, sender) => {
   switch (message.key) {
     case 'toggleSaka':
       toggleSaka();
@@ -140,7 +140,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
   }
 });
 
-chrome.runtime.onMessageExternal.addListener(message => {
+browser.runtime.onMessageExternal.addListener(message => {
   switch (message) {
     case 'toggleSaka':
       toggleSaka();
@@ -150,7 +150,7 @@ chrome.runtime.onMessageExternal.addListener(message => {
   }
 });
 
-chrome.contextMenus.create({
+browser.contextMenus.create({
   title: 'Saka',
   contexts: ['all'],
   onclick: () => toggleSaka()

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Saka",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": "Sufyan Dawoodjee, Uzair Shamim",
   "description": "Saka - elegent tab search, selection, and beyond",
   "manifest_version": 2,


### PR DESCRIPTION
## Type of Change
> Put an [x] for the relevant option
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary Of Changes
#### Why is this change needed?
Saka is not triggered when other extensions call the `browser.runtime.sendMessage` API 📬. This was caused by Saka relying on the `chrome.*` APIs in `background_page/index.js` instead of using the `browser.*` APIs.

#### Does this close any current open issues?
Fixes #9 

## Checklist
- [x] Tests are passing locally
- [ ] Updated the README/Wiki documentation (if relevant)

## Additional Comments
N/A
