### PR TITLE
Fix for fuzzy search penalizing long titles/urls

### DIFF
--- a/manifest/common.json
+++ b/manifest/common.json
@@ -1,6 +1,6 @@
 {
   "name": "Saka",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": "Sufyan Dawoodjee, Uzair Shamim",
   "description": "Saka - elegent tab search, selection, and beyond",
   "manifest_version": 2,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -40,7 +40,8 @@ export async function getFilteredSuggestions(
     threshold,
     minMatchCharLength: 1,
     includeMatches: true,
-    keys
+    keys,
+    distance: 500
   });
 
   return fuse.search(searchString).map(({ item, matches, score }) => ({


### PR DESCRIPTION
## Type of Change
> Put an [x] for the relevant option
- [x] Bugfix/Cleanup (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary Of Changes
#### Why is this change needed?
When users search they expect to match on the whole title or url. However the default setting in Fuse will penalize strings that have matches further from the start. This is determined by the location (point of reference) the distance (the penalty free zone) and the threshold (how close the string must match the search).

This fixes the issue where certain URLs would get ranked low because we were not specifying a large enough distance, thus causing them to be penalized by Fuse.

#### Does this close any open issues?
Fixes #54

## Checklist
- [x] Tests are passing locally
- [ ] Updated the README/Wiki documentation (if relevant)

## Additional Comments
N/A
