### PR TITLE
Removed onMouseEnter event from ModeSwitcher

### DIFF
--- a/src/saka/Main/Components/ModeSwitcher/index.jsx
+++ b/src/saka/Main/Components/ModeSwitcher/index.jsx
@@ -18,7 +18,6 @@ export default ({ mode, setMode }) => {
             : {}
         }
         onClick={() => setMode(suggestion.mode)}
-        onMouseEnter={() => setMode(suggestion.mode)}
       >
         <Icon icon={suggestion.icon} color={color} />
       </div>

--- a/test/ModeSwitcher.test.js
+++ b/test/ModeSwitcher.test.js
@@ -28,10 +28,6 @@ describe('ModeSwitcher component ', () => {
     fireEvent.click(getByText('restore_page'), 'click');
     await flushPromises();
     expect(setMode.mock.calls.length).toBe(1);
-
-    fireEvent.mouseEnter(getByText('bookmark_border'), 'mouseEnter');
-    await flushPromises();
-    expect(setMode.mock.calls.length).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Type of Change
> Put an [x] for the relevant option
- [x] Bugfix/Cleanup (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary Of Changes
#### Why is this change needed?
Fixes the issue with accidentally triggering mode switch when moving the mouse to click the search bar/suggestion

#### Does this close any open issues?
Resolves #80 

## Checklist
- [x] Tests are passing locally
- [ ] Updated the README/Wiki documentation (if relevant)

## Additional Comments
N/A
