### PR TITLE
Focus tab if existing for bookmarks & history

### DIFF
--- a/src/suggestion_engine/server/index.js
+++ b/src/suggestion_engine/server/index.js
@@ -13,10 +13,9 @@ async function focusOrCreateTab(url) {
 
     await browser.tabs.update(existingTab.id, { active: true });
     await browser.windows.update(existingTab.windowId, { focused: true });
-    return;
+  } else {
+    await browser.tabs.create({ url });
   }
-
-  await browser.tabs.create({ url });
 }
 
 export async function activateSuggestion(suggestion) {

--- a/src/suggestion_engine/server/index.js
+++ b/src/suggestion_engine/server/index.js
@@ -4,6 +4,21 @@ export async function getSuggestions([mode, searchString]) {
   return providers[mode](searchString);
 }
 
+async function focusOrCreateTab(url) {
+  const matchingTabs = await browser.tabs.query({ url });
+
+  if (matchingTabs && matchingTabs.length > 0) {
+    // If multiple matching tabs then just focus the first one
+    const existingTab = matchingTabs[0];
+
+    await browser.tabs.update(existingTab.id, { active: true });
+    await browser.windows.update(existingTab.windowId, { focused: true });
+    return;
+  }
+
+  await browser.tabs.create({ url });
+}
+
 export async function activateSuggestion(suggestion) {
   switch (suggestion.type) {
     case 'tab':
@@ -14,10 +29,10 @@ export async function activateSuggestion(suggestion) {
       await browser.sessions.restore(suggestion.sessionId);
       break;
     case 'bookmark':
-      await browser.tabs.create({ url: suggestion.url });
+      await focusOrCreateTab(suggestion.url);
       break;
     case 'history':
-      await browser.tabs.create({ url: suggestion.url });
+      await focusOrCreateTab(suggestion.url);
       break;
     case 'recentlyViewed':
       await activateSuggestion({

--- a/test/suggestion_engine/server/index.test.js
+++ b/test/suggestion_engine/server/index.test.js
@@ -65,7 +65,7 @@ test('should call appropriate activation methods', async () => {
 
 test('should focus bookmark and history tabs if already open', async () => {
   browser.flush();
-  browser.tabs.query.returns(Promise.resolve([{ id: '1', windowId: '1' }]));
+  browser.tabs.query.resolves([{ id: '1', windowId: '1' }]);
   await activateSuggestion({
     type: 'bookmark'
   });
@@ -73,7 +73,7 @@ test('should focus bookmark and history tabs if already open', async () => {
   expect(browser.windows.update.calledOnce).toEqual(true);
 
   browser.flush();
-  browser.tabs.query.returns(Promise.resolve([{ id: '1', windowId: '1' }]));
+  browser.tabs.query.resolves([{ id: '1', windowId: '1' }]);
   await activateSuggestion({
     type: 'history'
   });

--- a/test/suggestion_engine/server/index.test.js
+++ b/test/suggestion_engine/server/index.test.js
@@ -63,6 +63,24 @@ test('should call appropriate activation methods', async () => {
   expect(browser.tabs.update.calledOnce).toEqual(true);
 });
 
+test('should focus bookmark and history tabs if already open', async () => {
+  browser.flush();
+  browser.tabs.query.returns(Promise.resolve([{ id: '1', windowId: '1' }]));
+  await activateSuggestion({
+    type: 'bookmark'
+  });
+  expect(browser.tabs.update.calledOnce).toEqual(true);
+  expect(browser.windows.update.calledOnce).toEqual(true);
+
+  browser.flush();
+  browser.tabs.query.returns(Promise.resolve([{ id: '1', windowId: '1' }]));
+  await activateSuggestion({
+    type: 'history'
+  });
+  expect(browser.tabs.update.calledOnce).toEqual(true);
+  expect(browser.windows.update.calledOnce).toEqual(true);
+});
+
 test('should call close tab API', async () => {
   const suggestion = {
     tabId: 1


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix/Cleanup (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary Of Changes
This change makes saka focus any existing tabs that match the URL for bookmarks & history searches, falling back to creating a new tab if none are found.

#### Why is this change needed?
Love the extension and I have been using it for quite a while now. I primarily use it for bookmark searching which is my default mode (although I'd love to have a unified search mode!). I commonly open bookmarks that I already have open in an active tab which will then open a new tab. I find this annoying as I end up with multiple of the same page open.

I think this change is the ideal behaviour but happy to discuss.

#### Does this close any open issues?
No

## Checklist
- [x] Tests are passing locally
